### PR TITLE
feat: automatically convert num -> cat

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
-git+https://github.com/sbrugman/SDGym.git@v0.2.2-hw
+git+https://github.com/sbrugman/SDGym.git@v0.2.2-ex
 xgboost==1.3.3
 pandas_profiling


### PR DESCRIPTION
If the number fo distinct values of a numeric column is lower than a given threshold, it is interpreted as categorical. The threshold is given via `load_dataset`'s name. 

Ex: 
- "census_u50"

The "zc[percentage]" gives a warning for numeric columns for which the 0 value's frequency is higher than the threshold 0.4 (for instance indicating missing values). These could be split into two variables (binary mask + numeric).

Ex:
- "covtype_numeric_u20_zc0.4"